### PR TITLE
Update client to the latest version of Threat Stack V2 Api.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Or install it yourself as:
 You can access all attributes on responses thanks to the method_missing function in Ruby. We only munged the attributes that don't correspond to snake_case. If you want to see a list of all available attributes for a serializable response object, simply do something like this:
 
 ```
-client = Threatstack::Client.new(API_TOKEN, organization_id: ORG_ID)
-[threatstack] main> ts.alerts.first.attrs
+client = Threatstack::Client.new(API_TOKEN, organization_id: ORG_ID, api_key: API_KEY)
+[threatstack] main> ts.alerts("active").first.attrs
 => [:id,
  :title,
  :type,
@@ -50,7 +50,7 @@ client = Threatstack::Client.new(API_TOKEN, organization_id: ORG_ID)
 ```
 client = Threatstack::Client.new(API_TOKEN, organization_id: ORG_ID)
 ## All these are optional url params. See the Threatstack API Docs
-alert = client.alerts(start: 3.days.ago, end: Time.now, count: 5).last
+alert = client.alerts("active", start: 3.days.ago, end: Time.now, count: 5).last
 => #<Threatstack::Alert:0x007fde0b01cbd8
  @raw=
   {"created_at"=>1496850520000,
@@ -66,7 +66,7 @@ count = alert.count
 You can also limit the response if that's important to you:
 
 ```
-client.alerts(fields: ['title', 'alerts'])
+client.alerts("active", fields: ['title', 'alerts'])
 => [#<Threatstack::Alert:0x007fd61348c768
   @raw={"title"=>"CloudTrail Activity (IAM Policy Changes) : CreateAccessKey by ryan_canty", "severity"=>2}>]
 ```
@@ -80,7 +80,7 @@ client.alert('1234567890')
 ### Agents
 
 ```
-client.agents
+client.agents('online')
 =>  [#<Threatstack::Response:0x007fa262b0b2e0 @raw={...}> ]
 client.agent('123123123')
 =>  #<Threatstack::Agent:0x007fa262b0b2e0 @raw={...}>

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Or install it yourself as:
 You can access all attributes on responses thanks to the method_missing function in Ruby. We only munged the attributes that don't correspond to snake_case. If you want to see a list of all available attributes for a serializable response object, simply do something like this:
 
 ```
-client = Threatstack::Client.new(API_TOKEN, organization_id: ORG_ID, api_key: API_KEY)
+client = Threatstack::Client.new(organization_id: ORG_ID, api_key: API_KEY)
 [threatstack] main> ts.alerts("active").first.attrs
 => [:id,
  :title,
@@ -48,7 +48,7 @@ client = Threatstack::Client.new(API_TOKEN, organization_id: ORG_ID, api_key: AP
 ### Alerts
 
 ```
-client = Threatstack::Client.new(API_TOKEN, organization_id: ORG_ID)
+client = Threatstack::Client.new(organization_id: ORG_ID)
 ## All these are optional url params. See the Threatstack API Docs
 alert = client.alerts("active", start: 3.days.ago, end: Time.now, count: 5).last
 => #<Threatstack::Alert:0x007fde0b01cbd8

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Or install it yourself as:
 You can access all attributes on responses thanks to the method_missing function in Ruby. We only munged the attributes that don't correspond to snake_case. If you want to see a list of all available attributes for a serializable response object, simply do something like this:
 
 ```
-client = Threatstack::Client.new(organization_id: ORG_ID, api_key: API_KEY)
+client = Threatstack::Client.new(ORG_ID, USER_ID, API_KEY)
 [threatstack] main> ts.alerts("active").first.attrs
 => [:id,
  :title,
@@ -48,7 +48,7 @@ client = Threatstack::Client.new(organization_id: ORG_ID, api_key: API_KEY)
 ### Alerts
 
 ```
-client = Threatstack::Client.new(organization_id: ORG_ID)
+client = Threatstack::Client.new(ORG_ID, USER_ID, API_KEY)
 ## All these are optional url params. See the Threatstack API Docs
 alert = client.alerts("active", start: 3.days.ago, end: Time.now, count: 5).last
 => #<Threatstack::Alert:0x007fde0b01cbd8

--- a/lib/threatstack/entities/agent.rb
+++ b/lib/threatstack/entities/agent.rb
@@ -4,18 +4,10 @@ module Threatstack
   class Agent
     include Serializable
     attributes :id, :instance_id, :status, :activated_at, :last_reported_at,
-      :version, :name, :description, :hostname, :tags, :agent_type
+      :version, :name, :description, :hostname, :tags, :agent_type, :kernel
 
     def tags
       raw['tags'].map{ |t| Tag.new(t) }
-    end
-
-    def ruleset_ids
-      raw['rulesets']
-    end
-
-    def rulesets
-      ruleset_ids.each { |id| client.ruleset(id) }
     end
   end
 end

--- a/lib/threatstack/entities/alert.rb
+++ b/lib/threatstack/entities/alert.rb
@@ -20,7 +20,7 @@ module Threatstack
     end
 
     def events
-      event_ids&.map{ |event_id| client.event(id, event_id)}
+      client.events(id)
     end
   end
 end

--- a/threatstack.gemspec
+++ b/threatstack.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "pry"
   spec.add_runtime_dependency "httparty"
+  spec.add_runtime_dependency "hawk-auth"
 end


### PR DESCRIPTION
Hello! Today we released significant updates to the Beta of our V2 API.
This PR updates this library to work with these changes.

Changes include:
- Adding HAWK authentication
- Update methods to always require a param that the api requires
- Add new endpoints and modify old ones to be more RESTful
- Remove methods for the endpoints that were removed

Please let me know if there are any changes you would like to the PR.

You can check out the updated docs: https://apidocs.threatstack.com/